### PR TITLE
Refactor script themes

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -54,4 +54,7 @@ checkEnvVars(){
     fi
 }
 
+# https://www.baeldung.com/linux/directory-md5-checksum
+# > Letters, numbers, dates, and how they should be sorted can change from locale to locale. This can change our results for directories residing on two systems with different locale settings.
+export LC_ALL=C
 checkEnvVars

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -54,6 +54,13 @@ checkEnvVars(){
     fi
 }
 
+arrayToCommaSeparatedString(){
+    declare -n _retCommaSeparatedString="${1}"
+    declare -n _array="${2}"
+    printf -v _retCommaSeparatedString '%s,' "${_array[@]}"
+    _retCommaSeparatedString="${_retCommaSeparatedString::-1}"
+}
+
 # https://www.baeldung.com/linux/directory-md5-checksum
 # > Letters, numbers, dates, and how they should be sorted can change from locale to locale. This can change our results for directories residing on two systems with different locale settings.
 export LC_ALL=C

--- a/scripts/run_record.sh
+++ b/scripts/run_record.sh
@@ -6,45 +6,7 @@ source scripts/env.sh
 logInfo "Recording started..."
 source scripts/metadata.sh
 checkMetadataLock
-
-# returns the themes sorted minus the duplicates (repeated).
-# For finding the duplicates (repeated)
-# - ignore case option is used because some systems are case-insensitive. So "Adventure" and "adventure" will be counted as duplicates otherwise "adventure" recording will overwrite "Adventure" whilst the name will remain "Adventure.gif"
-# - Sort reverse is used because of the way "uniq --ignore-case" and "uniq --ignore-case --repeated" works.
-#
-# Example:
-#
-# The following is what the function will return. Notice it returns "Adventure"
-# printf "%s\n" "Tokyo" "Adventure" "adventure" | sort --ignore-case | uniq --ignore-case
-#Adventure
-#Tokyo
-#
-# Let's find the duplicates (repeated) without reverse sort. It returns "Adventure". This is not what we want to print out.
-# printf "%s\n" "Tokyo" "Adventure" "adventure" | sort --ignore-case | uniq --ignore-case --repeated
-#Adventure
-#
-# Now, let's find duplicates (repeated) with reverse. It returns what we want to display.
-# printf "%s\n" "Tokyo" "Adventure" "adventure" | sort --ignore-case --reverse | uniq --ignore-case --repeated
-#adventure
-sortThemesAndRemoveDuplicates(){
-    declare -n _retThemes2="${1}"
-
-    declare -a _duplicates
-    mapfile -t _duplicates < <(printf "%s\n" "${_retThemes2[@]}" \
-        | LC_ALL=C sort --ignore-case --reverse \
-        | uniq --ignore-case --repeated \
-        || true)
-    if (( ${#_duplicates[@]} > 0 ));then
-        logWarn "The followning ${#_duplicates[@]} themes are duplicates and discarded:"
-        logWarn "${_duplicates[@]}"
-        logWarn "Note: Having same name but with different cases (upper/lower) may cause the record to be overwitten on system that is case-insensitive"
-    fi
-
-    mapfile -t _retThemes2 < <( printf "%s\n" "${_retThemes2[@]}" \
-        | LC_ALL=C sort --ignore-case \
-        | uniq --ignore-case \
-        || true)
-}
+source scripts/themes.sh
 
 record() {
     declare -r _inputDir="${1}"
@@ -68,54 +30,13 @@ record() {
     vhs "${_tapePath}" &> /dev/null
 }
 
-getLimit(){
-    declare -n _retLimit="${1}"
-    declare -nr _themes="${2}"
-    declare -r _totalThemes="${#themes[@]}"
-
-    if (( "${ENV_THEMES_LIMIT:?}" == -1 )); then
-        _retLimit="${_totalThemes}"
-    elif (( "${ENV_THEMES_LIMIT}" > _totalThemes )); then
-        _retLimit="${_totalThemes}"
-    else
-        _retLimit="${ENV_THEMES_LIMIT}"
-    fi
-}
-
-getThemes(){
-    declare -n _retThemes="${1}"
-
-    if [[ "${ENV_THEMES:?}" == "all" ]]; then
-        # https://www.shellcheck.net/wiki/SC2207
-        # https://www.shellcheck.net/wiki/SC2312
-        # The command `vhs themes` outputs to stderr so the following line redirects stderr to stdout
-        mapfile -t _retThemes < <(vhs themes 2>&1 || true)
-    else
-        # Transform string like "Zenburn,Adventure" to an array
-        # https://stackoverflow.com/questions/10586153/how-to-split-a-string-into-an-array-in-bash
-        # https://www.shellcheck.net/wiki/SC2207
-        # shellcheck disable=SC2154,SC2312
-        mapfile -t _retThemes < <(printf "%s" "${ENV_THEMES}" | tr ',' '\n')
-    fi
-
-    if [[ "${#_retThemes[@]}" == 0 ]];then
-        logError "Number of themes is 0. Either the command 'vhs themes' didn't return any theme or ENV_THEMES is empty."
-        exit 1
-    fi
-
-    sortThemesAndRemoveDuplicates _retThemes
-
-    declare -i _limit
-    getLimit _limit _retThemes
-    _retThemes=("${themes[@]:0:${_limit}}")
-}
-
 # https://www.shellcheck.net/wiki/SC2115
 rm -fr "${ENV_OUTPUT_DIR:?}"/*
 mkdir -p "${ENV_OUTPUT_DIR}"/records
 
 declare -a themes
 getThemes themes
+exit 0
 declare -i counter=0
 for theme in "${themes[@]}"; do
     ((counter+=1))

--- a/scripts/run_record.sh
+++ b/scripts/run_record.sh
@@ -36,7 +36,8 @@ mkdir -p "${ENV_OUTPUT_DIR}"/records
 
 declare -a themes
 getThemes themes
-exit 0
+warnIfDuplicateThemes
+
 declare -i counter=0
 for theme in "${themes[@]}"; do
     ((counter+=1))

--- a/scripts/themes.sh
+++ b/scripts/themes.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# This file contains all function related to themes!
+#
+#
+# Here's an example of expected behaviour between uniq and duplicates (repeated):
+#
+# The following is what the function will return. Notice it returns "Adventure"
+# printf "%s\n" "Tokyo" "Adventure" "adventure" | sort --ignore-case | uniq --ignore-case
+#Adventure
+#Tokyo
+#
+# Let's find the duplicates (repeated) without reverse sort. It returns "Adventure". This is not what we want to print out.
+# printf "%s\n" "Tokyo" "Adventure" "adventure" | sort --ignore-case | uniq --ignore-case --repeated
+#Adventure
+#
+# Now, let's find duplicates (repeated) with reverse. It returns what we want to display.
+# printf "%s\n" "Tokyo" "Adventure" "adventure" | sort --ignore-case --reverse | uniq --ignore-case --repeated
+#adventure
+
+# getAllThemes returns all the themes (including duplicates) based on ENV_THEMES sorted
+getAllThemes(){
+    declare -n _retAllThemes="${1}"
+
+    if [[ "${ENV_THEMES:?}" == "all" ]]; then
+        # https://www.shellcheck.net/wiki/SC2207
+        # https://www.shellcheck.net/wiki/SC2312
+        # The command `vhs themes` outputs to stderr so the following line redirects stderr to stdout
+        mapfile -t _retAllThemes < <(vhs themes 2>&1 \
+            | sort --ignore-case \
+            || true)
+    else
+        # Transform string like "Zenburn,Adventure" to an array
+        # https://stackoverflow.com/questions/10586153/how-to-split-a-string-into-an-array-in-bash
+        # https://www.shellcheck.net/wiki/SC2207
+        # shellcheck disable=SC2154,SC2312
+        mapfile -t _retAllThemes < <(printf "%s" "${ENV_THEMES}" \
+            | tr ',' '\n' \
+            | sort --ignore-case)
+    fi
+
+    if [[ "${#_retAllThemes[@]}" == 0 ]];then
+        logError "Number of themes is 0. Either the command 'vhs themes' didn't return any theme or ENV_THEMES is empty."
+        exit 1
+    fi
+}
+
+
+# getAllThemeRepeatedDuplicates gets all duplicates (repeated) which are excluded from the function getAllUniqThemes
+# For finding the duplicates (repeated)
+# - ignore case option is used because some systems are case-insensitive. So "Adventure" and "adventure" will be counted as duplicates otherwise "adventure" recording will overwrite "Adventure" whilst the name will remain "Adventure.gif"
+# - Sort reverse is used because of the way "uniq --ignore-case" and "uniq --ignore-case --repeated" works.
+#
+
+#
+getAllThemeRepeatedDuplicates(){
+    declare -n _retDuplicates="${1}"
+    getAllThemes _retDuplicates
+    mapfile -t _retDuplicates < <(printf "%s\n" "${_retDuplicates[@]}" \
+        | sort --ignore-case --reverse \
+        | uniq --ignore-case --repeated \
+        || true)
+}
+
+# getAllUniqThemes returns all themes excluding duplicates (repeated)
+getAllUniqThemes(){
+    declare -n _retUniqThemes="${1}"
+    getAllThemes _retUniqThemes
+    mapfile -t _retUniqThemes < <( printf "%s\n" "${_retUniqThemes[@]}" \
+        | uniq --ignore-case \
+        || true)
+}
+
+getLimit(){
+    declare -n _retLimit="${1}"
+    declare -nr _themes="${2}"
+    declare -r _totalThemes="${#themes[@]}"
+
+    if (( "${ENV_THEMES_LIMIT:?}" == -1 )); then
+        _retLimit="${_totalThemes}"
+    elif (( "${ENV_THEMES_LIMIT}" > _totalThemes )); then
+        _retLimit="${_totalThemes}"
+    else
+        _retLimit="${ENV_THEMES_LIMIT}"
+    fi
+}
+
+getThemes(){
+    declare -n _retThemes="${1}"
+    getAllUniqThemes _retThemes
+    declare -i _limit
+    getLimit _limit
+    _retThemes=("${_retThemes[@]:0:${_limit}}")
+}
+


### PR DESCRIPTION
- Extract themes functionalities to its own script: themes.sh
- Refactor the tests to make it cleaner
- Add test for metadata
- metadata includes themes recorded count, themes recorded, duplicate themes count, and duplicate themes